### PR TITLE
Move to Go 1.13+ errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,9 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11.1
+      - image: cimg/go:1.14
     steps:
       - checkout
-      - run: go get -u golang.org/x/lint/golint
-      - run: golint
       - run: go vet ./...
       - run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
       - run: bash <(curl -s https://codecov.io/bash)

--- a/example/main.go
+++ b/example/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/int128/go-yahoo-weather/weather"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"os"
+
+	"github.com/int128/go-yahoo-weather/weather"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/int128/go-yahoo-weather
 
-require (
-	github.com/go-test/deep v1.0.1
-	github.com/pkg/errors v0.8.0
-)
+go 1.13
+
+require github.com/go-test/deep v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/weather/client_test.go
+++ b/weather/client_test.go
@@ -113,7 +113,7 @@ func TestClient_Get_Error400(t *testing.T) {
 	t.Log(err)
 	errResp := weather.GetErrorResponse(err)
 	if errResp == nil {
-		t.Errorf("errResp wants non-nil but nil")
+		t.Fatalf("errResp wants non-nil but nil")
 	}
 	if errResp.Code() != 400 {
 		t.Errorf("Code wants 400 but %d", errResp.Code())
@@ -149,7 +149,7 @@ func TestClient_Get_Error401(t *testing.T) {
 	t.Log(err)
 	errResp := weather.GetErrorResponse(err)
 	if errResp == nil {
-		t.Errorf("errResp wants non-nil but nil")
+		t.Fatalf("errResp wants non-nil but nil")
 	}
 	if errResp.Code() != 401 {
 		t.Errorf("Code wants 401 but %d", errResp.Code())
@@ -185,7 +185,7 @@ func TestClient_Get_Error403(t *testing.T) {
 	t.Log(err)
 	errResp := weather.GetErrorResponse(err)
 	if errResp == nil {
-		t.Errorf("errResp wants non-nil but nil")
+		t.Fatalf("errResp wants non-nil but nil")
 	}
 	if errResp.Code() != 403 {
 		t.Errorf("Code wants 403 but %d", errResp.Code())

--- a/weather/response.go
+++ b/weather/response.go
@@ -1,12 +1,11 @@
 package weather
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Response represents a response from Weather API.
@@ -72,8 +71,9 @@ type ErrorResponse interface {
 
 // GetErrorResponse returns ErrorResponse if API returned an error response.
 func GetErrorResponse(err error) ErrorResponse {
-	if r, ok := errors.Cause(err).(ErrorResponse); ok {
-		return r
+	var v ErrorResponse
+	if errors.As(err, &v) {
+		return v
 	}
 	return nil
 }
@@ -85,7 +85,7 @@ type CoordinatesString string
 func (s CoordinatesString) Parse() (Coordinates, error) {
 	p := strings.SplitN(string(s), ",", 2)
 	if len(p) != 2 {
-		return Coordinates{}, errors.Errorf("invalid coordinates string: %s", s)
+		return Coordinates{}, fmt.Errorf("invalid coordinates string: %s", s)
 	}
 	lat, lon := p[1], p[0]
 
@@ -93,11 +93,11 @@ func (s CoordinatesString) Parse() (Coordinates, error) {
 	var err error
 	c.Latitude, err = strconv.ParseFloat(lat, 64)
 	if err != nil {
-		return Coordinates{}, errors.Wrapf(err, "error while parsing latitude %s", lat)
+		return Coordinates{}, fmt.Errorf("error while parsing latitude %s: %w", lat, err)
 	}
 	c.Longitude, err = strconv.ParseFloat(lon, 64)
 	if err != nil {
-		return Coordinates{}, errors.Wrapf(err, "error while parsing longitude %s", lon)
+		return Coordinates{}, fmt.Errorf("error while parsing longitude %s: %w", lon, err)
 	}
 	return c, nil
 }

--- a/weather/weather.go
+++ b/weather/weather.go
@@ -1,9 +1,8 @@
 package weather
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Weather represents weather at the coordinates.
@@ -37,7 +36,7 @@ func Parse(resp *Response) ([]Weather, error) {
 
 		weather.Coordinates, err = respFeature.Geometry.Coordinates.Parse()
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid coordinates")
+			return nil, fmt.Errorf("invalid coordinates: %w", err)
 		}
 
 		for _, respWeather := range respFeature.Property.WeatherList.Weather {
@@ -45,14 +44,14 @@ func Parse(resp *Response) ([]Weather, error) {
 			event.Rainfall = respWeather.Rainfall
 			event.Time, err = respWeather.Date.Parse()
 			if err != nil {
-				return nil, errors.Wrapf(err, "invalid date")
+				return nil, fmt.Errorf("invalid date: %w", err)
 			}
 			switch respWeather.Type {
 			case "observation":
 			case "forecast":
 				event.Forecast = true
 			default:
-				return nil, errors.Errorf("unknown weather type: %s", respWeather.Type)
+				return nil, fmt.Errorf("unknown weather type: %s", respWeather.Type)
 			}
 
 			weather.Events = append(weather.Events, event)


### PR DESCRIPTION
This will migrate error handling from `pkg/errors` to Go 1.13+ `errors`.